### PR TITLE
Adding requirement for iOS 11.0.1 or newer for property `biometryType`

### DIFF
--- a/BiometricAuthentication/BiometricAuthentication/Authentication/BioMetricAuthenticator.swift
+++ b/BiometricAuthentication/BiometricAuthentication/Authentication/BioMetricAuthenticator.swift
@@ -86,7 +86,7 @@ public extension BioMetricAuthenticator {
     
     /// checks if face id is avaiable on device
     public func faceIDAvailable() -> Bool {
-        if #available(iOS 11.0, *) {
+        if #available(iOS 11.0.1, *) {
             let context = LAContext()
             return (context.canEvaluatePolicy(LAPolicy.deviceOwnerAuthentication, error: nil) && context.biometryType == .faceID)
         }


### PR DESCRIPTION
Fix for "Property `biometryType` is only available on iOS 11.0.1 or newer".
https://openradar.appspot.com/36064151
https://github.com/mshibanami/BiometryTypeBugWorkaround