### PR TITLE
Fix Xcode 10 build error

### DIFF
--- a/BiometricAuthentication/BiometricAuthentication/Authentication/BioMetricAuthenticator.swift
+++ b/BiometricAuthentication/BiometricAuthentication/Authentication/BioMetricAuthenticator.swift
@@ -114,7 +114,7 @@ extension BioMetricAuthenticator {
             DispatchQueue.main.async {
                 if success { successBlock() }
                 else {
-                    let errorType = AuthenticationError.init(error: err as! LAError)
+                    let errorType = AuthenticationError.`init`(error: err as! LAError)
                     failureBlock(errorType)
                 }
             }


### PR DESCRIPTION
Fixes the issue #20. <pre>AuthenticationError.&#x60;init&#x60;(error: err as! LAError)</pre> worked for me but not <pre>AuthenticationError.init(error: err as! LAError)</pre>