### PR TITLE
Extend AuthenticationError with Error protocol

### DIFF
--- a/BiometricAuthentication/BiometricAuthentication/Authentication/AuthenticationErrors.swift
+++ b/BiometricAuthentication/BiometricAuthentication/Authentication/AuthenticationErrors.swift
@@ -27,7 +27,7 @@ import Foundation
 import LocalAuthentication
 
 /// Authentication Errors
-public enum AuthenticationError {
+public enum AuthenticationError: Error {
     
     case failed, canceledByUser, fallback, canceledBySystem, passcodeNotSet, biometryNotAvailable, biometryNotEnrolled, biometryLockedout, other
     


### PR DESCRIPTION
I find it useful to add Error protocol to AuthenticationError.
Developers can pass it to other APIs as an error type