### PR TITLE
Modify the return value type of canAuthenticate() 

### DIFF
--- a/BiometricAuthentication/BiometricAuthentication/Authentication/BioMetricAuthenticator.swift
+++ b/BiometricAuthentication/BiometricAuthentication/Authentication/BioMetricAuthenticator.swift
@@ -96,13 +96,8 @@ public extension BioMetricAuthenticator {
         }
         
         // authenticate
-        if #available(iOS 9.0, *) {
-            BioMetricAuthenticator.shared.evaluate(policy: LAPolicy.deviceOwnerAuthentication, with: context, reason: reasonString, success: successBlock, failure: failureBlock)
-        } else {
-            // Fallback on earlier versions
             BioMetricAuthenticator.shared.evaluate(policy: LAPolicy.deviceOwnerAuthenticationWithBiometrics, with: context, reason: reasonString, success: successBlock, failure: failureBlock)
         }
-    }
     
     /// Check for device passcode authentication
     class func authenticateWithPasscode(reason: String, cancelTitle: String? = "", success successBlock:@escaping AuthenticationSuccess, failure failureBlock:@escaping AuthenticationFailure) {

--- a/BiometricAuthentication/BiometricAuthentication/Authentication/BioMetricAuthenticator.swift
+++ b/BiometricAuthentication/BiometricAuthentication/Authentication/BioMetricAuthenticator.swift
@@ -55,7 +55,7 @@ open class BioMetricAuthenticator: NSObject {
 public extension BioMetricAuthenticator {
     
     /// checks if biometric authentication can be performed currently on the device.
-    class func canAuthenticate() -> Bool {
+    class func canAuthenticate() -> CheckAuthenticateAbleResult<AuthenticationError> {
         
         var isBiometricAuthenticationAvailable = false
         var error: NSError? = nil
@@ -63,7 +63,16 @@ public extension BioMetricAuthenticator {
         if LAContext().canEvaluatePolicy(LAPolicy.deviceOwnerAuthenticationWithBiometrics, error: &error) {
             isBiometricAuthenticationAvailable = (error == nil)
         }
-        return isBiometricAuthenticationAvailable
+        
+        if isBiometricAuthenticationAvailable,
+            error == nil {
+            return CheckAuthenticateAbleResult.success
+        } else if let err = error{
+            let authenticationError = AuthenticationError.initWithError(err as! LAError)
+            return CheckAuthenticateAbleResult.failure(authenticationError)
+        } else {
+            return CheckAuthenticateAbleResult.failure(nil)
+        }
     }
     
     /// Check for biometric authentication
@@ -87,7 +96,12 @@ public extension BioMetricAuthenticator {
         }
         
         // authenticate
-        BioMetricAuthenticator.shared.evaluate(policy: LAPolicy.deviceOwnerAuthenticationWithBiometrics, with: context, reason: reasonString, success: successBlock, failure: failureBlock)
+        if #available(iOS 9.0, *) {
+            BioMetricAuthenticator.shared.evaluate(policy: LAPolicy.deviceOwnerAuthentication, with: context, reason: reasonString, success: successBlock, failure: failureBlock)
+        } else {
+            // Fallback on earlier versions
+            BioMetricAuthenticator.shared.evaluate(policy: LAPolicy.deviceOwnerAuthenticationWithBiometrics, with: context, reason: reasonString, success: successBlock, failure: failureBlock)
+        }
     }
     
     /// Check for device passcode authentication

--- a/BiometricAuthentication/BiometricAuthentication/Authentication/CheckAuthenticateAbleResult.swift
+++ b/BiometricAuthentication/BiometricAuthentication/Authentication/CheckAuthenticateAbleResult.swift
@@ -1,0 +1,16 @@
+//
+//  CheckAuthenticateAbleResult.swift
+//  BiometricAuthentication
+//
+//  Created by linjj on 2018/12/13.
+//  Copyright © 2018 Rushi Sangani. All rights reserved.
+//
+
+import Foundation
+
+public enum CheckAuthenticateAbleResult<T> {
+    case success
+    case failure(T?)
+}
+
+

--- a/BiometricAuthenticationExample/BiometricAuthenticationExample/ViewController.swift
+++ b/BiometricAuthenticationExample/BiometricAuthenticationExample/ViewController.swift
@@ -34,6 +34,28 @@ class ViewController: UIViewController {
         // Set AllowableReuseDuration in seconds to bypass the authentication when user has just unlocked the device with biometric
         BioMetricAuthenticator.shared.allowableReuseDuration = 60
         
+        // check biometric authentication usable
+        let url = BioMetricAuthenticator.canAuthenticate()
+        switch url {
+            
+        case .failure(let error):
+            if error == .biometryNotAvailable {
+                showErrorAlert(message: "Biometry is not available on the device or disabled in settings.")
+            } else if error == .biometryNotEnrolled {
+                showErrorAlert(message: "The user has no enrolled biometric identities.")
+            } else if error == .biometryLockedout {
+                showErrorAlert(message: "Biometry is locked because there were too many failed attempts.")
+            } else {
+                showErrorAlert(message: "unkown error")
+            }
+        case .success:
+            startAuthentication()
+        
+        }
+
+    }
+    
+    func startAuthentication() {
         // start authentication
         BioMetricAuthenticator.authenticateWithBioMetrics(reason: "", success: {
             


### PR DESCRIPTION
Modify the return value type of canAuthenticate()  to verify that the device and settings are available before authenticating