### PR TITLE
Show correct message when biometry is not enrolled

### DIFF
--- a/BiometricAuthentication/BiometricAuthentication/Authentication/AuthenticationErrors.swift
+++ b/BiometricAuthentication/BiometricAuthentication/Authentication/AuthenticationErrors.swift
@@ -67,7 +67,17 @@ public enum AuthenticationError: Error {
         case .biometryNotAvailable:
             return kBiometryNotAvailableReason
         case .biometryNotEnrolled:
-            return authentication.faceIDAvailable() ? kNoFaceIdentityEnrolled : kNoFingerprintEnrolled
+            let context = LAContext()
+            _ = context.canEvaluatePolicy(LAPolicy.deviceOwnerAuthenticationWithBiometrics, error: nil)
+            if #available(iOS 11.0, *) {
+                switch context.biometryType {
+                case .touchID: return kNoFingerprintEnrolled
+                case .faceID: return kNoFaceIdentityEnrolled
+                default: return kNoFaceIdentityEnrolled
+                }
+            } else {
+                return kNoFaceIdentityEnrolled
+            }
         case .biometryLockedout:
             return authentication.faceIDAvailable() ? kFaceIdPasscodeAuthenticationReason : kTouchIdPasscodeAuthenticationReason
         default:


### PR DESCRIPTION
`.faceIDAvailable()` always returns false if biometry is not enrolled which results in the TouchID message being shown regardless of device. This PR patches that bug without changing the existing functionality of `.faceIDAvailable()` so as not to introduce a potentially breaking change.

Reproduction Steps:
- Run the example app on a simulator that supports FaceID
- Disable biometrics by deselecting Hardware > Face ID > Enrolled
- Tap the "Biometric authentication" button in the example app

Observe: An alert prompts the user to enroll their fingerprints for Touch ID
Expected: An alert prompts the user to enroll their face for Face ID